### PR TITLE
some improvements to the Docker situation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,15 +128,29 @@ After completing all the steps from previous sections, do one of these:
 
 ### Production
 
+Build the containers:
+
+```shell
+docker-compose \
+    -f docker-compose.yml \
+    -f docker-compose.production.yml \
+    up --no-start --build
+```
+
 Run the containers:
 
 ```zsh
 docker-compose \
   -f docker-compose.yml \
   -f docker-compose.production.yml \
-  -f state/docker-compose.yml \
+  -f /var/lib/docker/volumes/specify7-test-panel_state/_data/docker-compose.yml \
   up --remove-orphans -d
 ```
+
+If
+`/var/lib/docker/volumes/specify7-test-panel_state/_data/docker-compose.yml`
+is not correct on your host, you can find the correct path using
+`docker volume ls` and `docker volume inspect`.
 
 Test Panel is now available at [https://localhost/](https://localhost/)
 

--- a/app/const/siteConfig.ts
+++ b/app/const/siteConfig.ts
@@ -15,6 +15,7 @@ export const customStaleAfter = 2 * staleAfter;
 
 // Path is relative to package.json
 export const stateDirectory = '../state';
+export const nginxConfDirectory = '../nginx.conf.d';
 
 // Refresh deployment's state every 10 seconds
 export const stateRefreshInterval = 10 * 1000;

--- a/app/pages/api/state/index.ts
+++ b/app/pages/api/state/index.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { stateDirectory } from '../../../const/siteConfig';
+import { stateDirectory, nginxConfDirectory } from '../../../const/siteConfig';
 import { fileExists, getUser } from '../../../lib/apiUtils';
 import path from 'path';
 import fs from 'fs';
@@ -15,7 +15,7 @@ import { RA } from '../../../lib/typescriptCommonTypes';
 import { User } from '../../../lib/user';
 
 const configurationFile = path.resolve(stateDirectory, 'configuration.json');
-const nginxConfigurationFile = path.resolve(stateDirectory, 'nginx.conf');
+const nginxConfigurationFile = path.resolve(nginxConfDirectory, 'nginx.conf');
 const dockerConfigurationFile = path.resolve(
   stateDirectory,
   'docker-compose.yml'

--- a/config/panel.conf
+++ b/config/panel.conf
@@ -43,3 +43,6 @@ server {
   }
 
 }
+
+
+include /etc/nginx/conf.d/servers/*.conf;

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -17,4 +17,5 @@ services:
       - nginx
     restart: unless-stopped
     volumes:
-      - './state:/home/node/state'
+      - 'state:/home/node/state'
+      - 'nginx-conf:/home/node/nginx.conf.d'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       - nginx
     restart: unless-stopped
     volumes:
+      - 'nginx-conf:/etc/nginx/conf.d/servers:ro'
       - './config/panel.conf:/etc/nginx/conf.d/default.conf:ro'
-      - './state/nginx.conf:/etc/nginx/conf.d/var.conf:ro'
 
       - './config/fullchain.pem:/etc/letsencrypt/fullchain.pem:ro'
       - './config/privkey.pem:/etc/letsencrypt/privkey.pem:ro'
@@ -36,6 +36,8 @@ services:
 
 volumes:
   database:
+  state:
+  nginx-conf:
 
 networks:
   database:


### PR DESCRIPTION
1. Use the node user that comes with node image instead of making
another user.
2. Use the node user for building. (Drop root privileges immediately.)
3. Use Docker volumes instead of bind mounts for files updated by the
panel. This avoids permissions issues with state directory on the host
file system.

Your dev environment is probably broken by this. I was only playing with the production setup.