### PR TITLE
feat: filter tags by architecture

### DIFF
--- a/app/const/localization.ts
+++ b/app/const/localization.ts
@@ -79,6 +79,7 @@ export const localization = {
   mb: 'MB',
   nameConflict:
     'Database with this name already exists. Please delete it first',
+  finalDatabaseName: 'Final database name:',
   container: 'Container',
   noLogsAvailable: 'No logs available for this container',
   failedToDownload: 'Failed to download',

--- a/app/lib/databaseNameHelper.ts
+++ b/app/lib/databaseNameHelper.ts
@@ -1,0 +1,11 @@
+/**
+ * Generate a database name with today's date suffix
+ * Format: {baseName}_YYYY_MM_DD
+ */
+export function generateDatabaseNameWithDate(baseName: string): string {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${baseName}_${year}_${month}_${day}`;
+}

--- a/app/pages/api/databases/[name]/export.ts
+++ b/app/pages/api/databases/[name]/export.ts
@@ -24,19 +24,13 @@ export default async function handler(
   const sanitizedFilename = String(databaseName).replace(/[^\w.-]/g, '_');
 
   try {
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="${sanitizedFilename}.sql"`
-    );
-
-    const child = spawn(
-      'mysqldump',
+    const result = await spawn(
+      'mariadb-dump',
       [
-        `-u${process.env.MYSQL_USERNAME}`,
-        `-p${process.env.MYSQL_PASSWORD}`,
-        `-h${process.env.MYSQL_HOST}`,
-        `--databases ${databaseName}`,
-        '--no-create-db',
+        `--user=${process.env.MYSQL_USERNAME}`,
+        `--password=${process.env.MYSQL_PASSWORD}`,
+        `--host=${process.env.MYSQL_HOST}`,
+        databaseName,
       ],
       {
         stdio: ['ignore', 'pipe', 'pipe'],
@@ -44,11 +38,16 @@ export default async function handler(
       }
     );
 
-    child.stdout.pipe(res);
-    child.stderr.on('data', (error) => {
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="${sanitizedFilename}.sql"`
+    );
+
+    result.stdout.pipe(res);
+    result.stderr.on('data', (error) => {
       throw new Error(error);
     });
-    await new Promise((resolve) => child.stdout.on('exit', resolve));
+    await new Promise((resolve) => result.stdout.on('exit', resolve));
   } catch (error) {
     res.status(500).json({
       error: (error as object).toString(),

--- a/app/pages/api/databases/[name]/export.ts
+++ b/app/pages/api/databases/[name]/export.ts
@@ -30,7 +30,8 @@ export default async function handler(
         `--user=${process.env.MYSQL_USERNAME}`,
         `--password=${process.env.MYSQL_PASSWORD}`,
         `--host=${process.env.MYSQL_HOST}`,
-        databaseName,
+        `--databases ${databaseName}`,
+        '--no-create-db',
       ],
       {
         stdio: ['ignore', 'pipe', 'pipe'],

--- a/app/pages/api/databases/upload.ts
+++ b/app/pages/api/databases/upload.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 
 import { getUser, run } from '../../../lib/apiUtils';
 import { connectToDatabase } from '../../../lib/database';
+import { generateDatabaseNameWithDate } from '../../../lib/databaseNameHelper';
 
 // First we need to disable the default body parser
 export const config = {
@@ -53,11 +54,7 @@ export default async function handler(
   if (databaseNameForm.match(/^\w+$/) === null)
     return res.status(400).json({ error: 'Database name is invalid' });
 
-  const today = new Date();
-  const year = today.getFullYear();
-  const month = String(today.getMonth() + 1).padStart(2, '0');
-  const day = String(today.getDate()).padStart(2, '0');
-  const databaseName = `${databaseNameForm}_${year}_${month}_${day}`;
+  const databaseName = generateDatabaseNameWithDate(databaseNameForm);
 
   const file = data.files.file as File | undefined;
 

--- a/app/pages/api/databases/upload.ts
+++ b/app/pages/api/databases/upload.ts
@@ -45,13 +45,19 @@ export default async function handler(
 
   if (typeof data === 'string') return res.status(400).json({ error: data });
 
-  const databaseName = data.fields.databaseName as string | undefined;
+  const databaseNameForm = data.fields.databaseName as string | undefined;
 
-  if (!databaseName)
+  if (!databaseNameForm)
     return res.status(400).json({ error: 'Database name is required' });
 
-  if (databaseName.match(/^\w+$/) === null)
+  if (databaseNameForm.match(/^\w+$/) === null)
     return res.status(400).json({ error: 'Database name is invalid' });
+
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  const databaseName = `${databaseNameForm}_${year}_${month}_${day}`;
 
   const file = data.files.file as File | undefined;
 

--- a/app/pages/api/databases/upload.ts
+++ b/app/pages/api/databases/upload.ts
@@ -117,7 +117,7 @@ export default async function handler(
     await connection.execute(`CREATE DATABASE \`${databaseName}\``);
     await run(
       [
-        `mysql -u${process.env.MYSQL_USERNAME} `,
+        `mariadb -u${process.env.MYSQL_USERNAME} `,
         `-p${process.env.MYSQL_PASSWORD} `,
         `-h${process.env.MYSQL_HOST} `,
         `--database "${databaseName}" < ${filePath}`,

--- a/app/pages/api/dockerhub/[image].ts
+++ b/app/pages/api/dockerhub/[image].ts
@@ -19,7 +19,9 @@ type Response = {
     readonly name: string;
     readonly last_updated: string;
     readonly digest: string;
-    readonly architecture: string;
+    readonly images: RA<{
+      readonly architecture: string;
+    }>;
   }>;
   readonly next: string | undefined;
 };

--- a/app/pages/api/dockerhub/[image].ts
+++ b/app/pages/api/dockerhub/[image].ts
@@ -19,6 +19,7 @@ type Response = {
     readonly name: string;
     readonly last_updated: string;
     readonly digest: string;
+    readonly architecture: string;
   }>;
   readonly next: string | undefined;
 };
@@ -35,7 +36,12 @@ const processTagsResponse = (tags: Response['results']): IR<DockerHubTag> =>
   Object.fromEntries(
     tags
       // Latest is an unpredictable branch, thus will exclude it
-      .filter(({ name }) => !name.startsWith('sha-') && name !== 'latest')
+      .filter(
+        ({ name, images }) =>
+          !name.startsWith('sha-') &&
+          name !== 'latest' &&
+          images.some(({ architecture }) => architecture === 'arm64')
+      )
       .map(({ name, last_updated, digest }) => [
         name,
         {

--- a/app/pages/databases/upload.tsx
+++ b/app/pages/databases/upload.tsx
@@ -6,6 +6,7 @@ import Layout from '../../components/Layout';
 import { useApi } from '../../components/useApi';
 import { useDatabases } from '../index';
 import { localization } from '../../const/localization';
+import { generateDatabaseNameWithDate } from '../../lib/databaseNameHelper';
 
 const bytesToMb = (size: number): number =>
   Math.round((size / 1024 / 1024) * 100) / 100;
@@ -22,7 +23,8 @@ export default function Index(): JSX.Element {
 
   const isConflict =
     typeof databases === 'object' &&
-    databases.some(({ name }) => name === databaseName);
+    Boolean(databaseName) &&
+    databases.some(({ name }) => name === generateDatabaseNameWithDate(databaseName));
 
   return (
     <Layout title={localization.uploadNewDatabase} protected>
@@ -91,6 +93,16 @@ export default function Index(): JSX.Element {
                 diskUsage.data.free + fileSize >= diskUsage.data.size * 0.99 ? (
                   <p>{localization.notEnoughSpace}</p>
                 ) : undefined}
+                {databaseName && (
+                  <div className="flex flex-col gap-y-1">
+                    <label className="text-sm font-medium text-gray-700">
+                      {localization.finalDatabaseName}
+                    </label>
+                    <div className="rounded bg-gray-100 p-2 font-mono text-sm">
+                      {generateDatabaseNameWithDate(databaseName)}
+                    </div>
+                  </div>
+                )}
                 <input
                   className={`cursor-pointer rounded-xl bg-green-500 p-3
                     hover:bg-green-800`}


### PR DESCRIPTION
Fixes #123

### Testing Instructions

- [ ] Go to select a Specify 7 version
- [ ] Verify that images not built for `arm64` do not appear (e.g. 

For example: https://hub.docker.com/r/specifyconsortium/specify7-service/tags?name=v7.9.6.1

<img width="864" height="554" alt="image" src="https://github.com/user-attachments/assets/7a17c726-1bcc-4901-8dd0-63a52cbf5753" />


In the current version (`main`): 
<img width="840" height="95" alt="image" src="https://github.com/user-attachments/assets/04f1e804-b28b-4df1-9100-4b36e8bdf0f7" />

On this branch, it should **not** be visible!